### PR TITLE
fix: exclude all .changeset markdown files from documentation label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,7 +8,7 @@ core:
 
 documentation:
 - changed-files:
-  - any-glob-to-any-file: ['**/*.md', '**/*.mdx', '!.changeset/*.md']
+  - any-glob-to-any-file: ['**/*.md', '**/*.mdx', '!.changeset/**/*.md']
 
 github-actions:
 - changed-files:


### PR DESCRIPTION
## Changes
<!-- Briefly describe the changes made in this PR -->

Improves the glob pattern in labeler.yml to properly exclude all markdown files in the .changeset directory from being labeled as documentation.

