### PR TITLE
chore: add type-check script to package.json

### DIFF
--- a/.changeset/loose-pianos-try.md
+++ b/.changeset/loose-pianos-try.md
@@ -1,0 +1,6 @@
+---
+"@offlegacy/git-intent-core": patch
+"git-intent": patch
+---
+
+chore: add type-check script to package.json

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,7 +36,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
-
       - name: Setup Node.js & pnpm cache
         uses: actions/setup-node@v4
         with:
@@ -45,6 +44,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Type check
+        run: pnpm type-check
 
       - name: Build packages
         run: pnpm build

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "turbo build && changeset publish",
-    "cli": "pnpm --filter='git-intent' start"
+    "cli": "pnpm --filter='git-intent' start",
+    "type-check": "turbo type-check"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,9 +13,7 @@
     "todo-driven"
   ],
   "license": "MIT",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "type": "module",
   "bin": {
     "git-intent": "./dist/index.cjs"
@@ -30,12 +28,11 @@
     "start": "node dist/index.cjs",
     "format": "biome format",
     "format:fix": "biome format --write",
-    "pkg:build:macos": "pnpm build && pkg . --no-bytecode -t node18-macos-arm64 -o build/git-intent-macos"
+    "pkg:build:macos": "pnpm build && pkg . --no-bytecode -t node18-macos-arm64 -o build/git-intent-macos",
+    "type-check": "tsc --noEmit"
   },
   "pkg": {
-    "assets": [
-      "dist/**/*"
-    ],
+    "assets": ["dist/**/*"],
     "outputPath": "build"
   },
   "dependencies": {

--- a/packages/cli/src/commands/commit.ts
+++ b/packages/cli/src/commands/commit.ts
@@ -1,4 +1,4 @@
-import { git, storage } from '@offlegacy/git-intent-core';
+import { gitService, storage } from '@offlegacy/git-intent-core';
 import chalk from 'chalk';
 import { Command } from 'commander';
 
@@ -17,7 +17,7 @@ const commit = new Command()
 
     const message = options.message ? `${currentCommit.message}\n\n${options.message}` : currentCommit.message;
 
-    await git.createCommit(message);
+    await gitService.createCommit(message);
     await storage.deleteCommit(currentCommit.id);
 
     console.log(chalk.green('✓ Intention completed and committed'));

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,4 +1,4 @@
-import { git, storage } from '@offlegacy/git-intent-core';
+import { gitService, storage } from '@offlegacy/git-intent-core';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import prompts from 'prompts';
@@ -48,7 +48,7 @@ const start = new Command()
       return;
     }
 
-    const currentBranch = await git.getCurrentBranch();
+    const currentBranch = await gitService.getCurrentBranch();
     targetCommit.status = 'in_progress';
     targetCommit.metadata.startedAt = new Date().toISOString();
     targetCommit.metadata.branch = currentBranch;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@offlegacy/git-intent-core",
   "version": "0.0.13",
-  "private": true,
   "description": "Core functionality for git-intent",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,12 +6,11 @@
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup"
+    "build": "tsup",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "fs-extra": "^11.3.0",

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -2,5 +2,4 @@ import { createTsupConfig } from '../../tsup.config.base';
 
 export default createTsupConfig({
   entry: ['src/index.ts'],
-  dts: true,
 });

--- a/tsup.config.base.ts
+++ b/tsup.config.base.ts
@@ -4,6 +4,7 @@ export function createTsupConfig(options: Partial<Options> = {}) {
   return defineConfig({
     format: ['esm', 'cjs'],
     clean: true,
+    dts: true,
     ...options,
   });
 }

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,10 @@
     },
     "clean": {
       "cache": false
+    },
+    "type-check": {
+      "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"],
+      "outputs": []
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -11,13 +11,14 @@
       "persistent": true
     },
     "test": {
-      "dependsOn": ["build"],
+      "dependsOn": ["^build"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
     },
     "clean": {
       "cache": false
     },
     "type-check": {
+      "dependsOn": ["^build"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"],
       "outputs": []
     }


### PR DESCRIPTION
This PR adds a new type-check script to the root package.json file to improve type safety and development workflow. The script runs `turbo type-check` to verify TypeScript types across the project.