### PR TITLE
feat: update existing active intent before setting a new one

### DIFF
--- a/src/core/commands/findActiveIntent.ts
+++ b/src/core/commands/findActiveIntent.ts
@@ -1,0 +1,8 @@
+import { db } from "../db";
+
+export async function findActiveIntent({ branchId }: { branchId: string }) {
+  return db.query.intents.findFirst({
+    where: (intents, { eq, and }) =>
+      and(eq(intents.branchId, branchId), eq(intents.status, "active")),
+  });
+}

--- a/src/core/commands/findActiveIntent.ts
+++ b/src/core/commands/findActiveIntent.ts
@@ -1,8 +1,20 @@
 import { db } from "../db";
+import type { Intent } from "../db/schema";
 
-export async function findActiveIntent({ branchId }: { branchId: string }) {
-  return db.query.intents.findFirst({
-    where: (intents, { eq, and }) =>
-      and(eq(intents.branchId, branchId), eq(intents.status, "active")),
-  });
+export async function findActiveIntent({
+  branchId,
+}: {
+  branchId: string;
+}): Promise<Intent | undefined> {
+  try {
+    return await db.query.intents.findFirst({
+      where: (intents, { eq, and }) =>
+        and(eq(intents.branchId, branchId), eq(intents.status, "active")),
+    });
+  } catch (error) {
+    console.error(error);
+    throw new Error(
+      `Failed to find active intent: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
 }

--- a/src/core/commands/index.ts
+++ b/src/core/commands/index.ts
@@ -1,2 +1,3 @@
+export * from "./findActiveIntent";
 export * from "./list";
 export * from "./start";

--- a/src/core/commands/start.ts
+++ b/src/core/commands/start.ts
@@ -17,7 +17,7 @@ export async function start({
       if (activeIntent) {
         db.update(intents)
           .set({
-            status: "completed",
+            status: "cancelled",
           })
           .where(eq(intents.id, activeIntent.id))
           .run();

--- a/src/core/commands/start.ts
+++ b/src/core/commands/start.ts
@@ -13,26 +13,26 @@ export async function start({
   try {
     const activeIntent = await findActiveIntent({ branchId });
 
-    if (activeIntent) {
-      db.update(intents)
-        .set({
-          status: "completed",
+    return db.transaction((tx) => {
+      if (activeIntent) {
+        db.update(intents)
+          .set({
+            status: "completed",
+          })
+          .where(eq(intents.id, activeIntent.id))
+          .run();
+      }
+
+      return tx
+        .insert(intents)
+        .values({
+          message,
+          status: "active",
+          branchId,
         })
-        .where(eq(intents.id, activeIntent.id))
-        .run();
-    }
-
-    const result = db
-      .insert(intents)
-      .values({
-        message,
-        status: "active",
-        branchId,
-      })
-      .returning()
-      .get();
-
-    return result;
+        .returning()
+        .get();
+    });
   } catch (error) {
     console.error("Failed to add new intent: ", error);
     throw new Error(

--- a/src/core/commands/start.ts
+++ b/src/core/commands/start.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import { db } from "../db";
-import { intents } from "../db/schema";
+import { type Intent, intents } from "../db/schema";
 import { findActiveIntent } from "./findActiveIntent";
 
 export async function start({
@@ -9,26 +9,34 @@ export async function start({
 }: {
   message: string;
   branchId: string;
-}) {
-  const activeIntent = await findActiveIntent({ branchId });
+}): Promise<Intent> {
+  try {
+    const activeIntent = await findActiveIntent({ branchId });
 
-  if (activeIntent) {
-    db.update(intents)
-      .set({
-        status: "completed",
+    if (activeIntent) {
+      db.update(intents)
+        .set({
+          status: "completed",
+        })
+        .where(eq(intents.id, activeIntent.id))
+        .run();
+    }
+
+    const result = db
+      .insert(intents)
+      .values({
+        message,
+        status: "active",
+        branchId,
       })
-      .where(eq(intents.id, activeIntent.id))
-      .run();
+      .returning()
+      .get();
+
+    return result;
+  } catch (error) {
+    console.error("Failed to add new intent: ", error);
+    throw new Error(
+      `Failed to create intent: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
   }
-
-  const result = db
-    .insert(intents)
-    .values({
-      message,
-      status: "active",
-      branchId,
-    })
-    .run();
-
-  return Number(result.lastInsertRowid);
 }

--- a/src/core/commands/start.ts
+++ b/src/core/commands/start.ts
@@ -1,13 +1,26 @@
+import { eq } from "drizzle-orm";
 import { db } from "../db";
 import { intents } from "../db/schema";
+import { findActiveIntent } from "./findActiveIntent";
 
-export function start({
+export async function start({
   message,
   branchId,
 }: {
   message: string;
   branchId: string;
 }) {
+  const activeIntent = await findActiveIntent({ branchId });
+
+  if (activeIntent) {
+    db.update(intents)
+      .set({
+        status: "completed",
+      })
+      .where(eq(intents.id, activeIntent.id))
+      .run();
+  }
+
   const result = db
     .insert(intents)
     .values({

--- a/src/ui/ActiveIntentBox.tsx
+++ b/src/ui/ActiveIntentBox.tsx
@@ -5,34 +5,21 @@ import { TitledBox } from "./Title";
 
 export const ActiveIntentBox = () => {
   const { isFocused } = useFocus();
-  const { activeIntentList } = useQuery();
+  const { activeIntent, error } = useQuery();
 
-  if (!Array.isArray(activeIntentList) || activeIntentList.length === 0) {
+  if (error) {
+    return (
+      <Box paddingLeft={1} borderStyle="round" flexDirection="column">
+        <Text color="red">Error: {error}</Text>
+      </Box>
+    );
+  }
+
+  if (!activeIntent) {
     return (
       <Box paddingLeft={1} borderStyle="round" flexDirection="column">
         <Text>No active intent found.</Text>
       </Box>
-    );
-  }
-
-  if (activeIntentList.length > 1) {
-    return (
-      <Box paddingLeft={1} borderStyle="round" flexDirection="column">
-        <Text color="yellow">
-          Warning: Multiple active intents found. Showing first one.
-        </Text>
-        <Text>
-          {activeIntentList[0]?.message || "Intent message unavailable"}
-        </Text>
-      </Box>
-    );
-  }
-
-  const intent = activeIntentList[0];
-
-  if (!intent) {
-    throw new Error(
-      "Invariant violation: intent should exist when activeList.length !== 0",
     );
   }
 
@@ -44,7 +31,7 @@ export const ActiveIntentBox = () => {
       flexDirection="column"
     >
       <TitledBox title="Active Intent">
-        <Text>{`${intent.message}`}</Text>
+        <Text>{`${activeIntent.message}`}</Text>
       </TitledBox>
     </Box>
   );

--- a/src/ui/contexts/QueryContext.tsx
+++ b/src/ui/contexts/QueryContext.tsx
@@ -37,8 +37,8 @@ export const QueryProvider = ({ children }: { children: ReactNode }) => {
     const loadActiveIntent = async () => {
       try {
         setError(null);
-        const projectId = ensureProject();
-        const branchId = ensureBranch(projectId);
+        const projectId = await ensureProject();
+        const branchId = await ensureBranch(projectId);
         const activeIntent = await commands.findActiveIntent({ branchId });
         setActiveIntent(activeIntent || null);
       } catch (error) {

--- a/src/ui/contexts/QueryContext.tsx
+++ b/src/ui/contexts/QueryContext.tsx
@@ -1,4 +1,10 @@
-import { createContext, type ReactNode, useContext, useState } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 import * as commands from "../../core/commands";
 import type { Intent } from "../../core/db/schema";
 import { ensureBranch } from "../../core/utils/branch";
@@ -8,7 +14,8 @@ type QueryContextType = {
   query: string;
   setQuery: (query: string) => void;
   submitQuery: () => void;
-  activeIntentList: Intent[];
+  activeIntent: Intent | null;
+  error: string | null;
 };
 
 const QueryContext = createContext<QueryContextType | null>(null);
@@ -21,32 +28,53 @@ export const useQuery = () => {
   return context;
 };
 
-const getActiveIntent = () => {
-  const activeIntentArray = commands.list("active");
-  return Array.isArray(activeIntentArray) ? activeIntentArray : [];
-};
-
 export const QueryProvider = ({ children }: { children: ReactNode }) => {
   const [query, setQuery] = useState("");
+  const [activeIntent, setActiveIntent] = useState<Intent | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-  const [activeIntentList, setActiveIntentList] = useState(getActiveIntent);
+  useEffect(() => {
+    const loadActiveIntent = async () => {
+      try {
+        setError(null);
+        const projectId = ensureProject();
+        const branchId = ensureBranch(projectId);
+        const activeIntent = await commands.findActiveIntent({ branchId });
+        setActiveIntent(activeIntent || null);
+      } catch (error) {
+        console.error("Failed to load active intent:", error);
+        setError("Failed to load active intent");
+        setActiveIntent(null);
+      }
+    };
+
+    loadActiveIntent();
+  }, []);
 
   const submitQuery = async () => {
     if (query.trim() === "") {
       return;
     }
 
-    const projectId = await ensureProject();
-    const branchId = await ensureBranch(projectId);
-    await commands.start({ message: query, branchId });
-
-    setActiveIntentList(getActiveIntent());
-    setQuery("");
+    try {
+      setError(null);
+      const projectId = await ensureProject();
+      const branchId = await ensureBranch(projectId);
+      const newActiveIntent = await commands.start({
+        message: query,
+        branchId,
+      });
+      setActiveIntent(newActiveIntent);
+      setQuery("");
+    } catch (error) {
+      console.error("Failed to create intent:", error);
+      setError("Failed to create intent. Please try again.");
+    }
   };
 
   return (
     <QueryContext.Provider
-      value={{ query, setQuery, submitQuery, activeIntentList }}
+      value={{ query, setQuery, submitQuery, activeIntent, error }}
     >
       {children}
     </QueryContext.Provider>

--- a/src/ui/contexts/QueryContext.tsx
+++ b/src/ui/contexts/QueryContext.tsx
@@ -38,7 +38,7 @@ export const QueryProvider = ({ children }: { children: ReactNode }) => {
 
     const projectId = await ensureProject();
     const branchId = await ensureBranch(projectId);
-    commands.start({ message: query, branchId });
+    await commands.start({ message: query, branchId });
 
     setActiveIntentList(getActiveIntent());
     setQuery("");


### PR DESCRIPTION
Previously, running `start` command does not check if any intent is active. Since having two active intents does not make sense, it now checks if there is any intent with active status, set it to complete and insert a new one.

Changes:
- newly introduced `findActiveIntent` command simplifies the logic to fetch the active intent in the UI side.
- `start` command now returns the row that got inserted.