### PR TITLE
fix: use transaction context for database update in start command

### DIFF
--- a/src/core/commands/start.ts
+++ b/src/core/commands/start.ts
@@ -15,7 +15,7 @@ export async function start({
 
     return db.transaction((tx) => {
       if (activeIntent) {
-        db.update(intents)
+        tx.update(intents)
           .set({
             status: "cancelled",
           })


### PR DESCRIPTION
- Fixed a bug where database update was using direct `db` instead of transaction context `tx`
- This ensures proper atomicity when cancelling active intents before starting new ones