### PR TITLE
fix(ci): workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,5 +1,8 @@
 name: Code quality
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/offlegacy/git-intent/security/code-scanning/8](https://github.com/offlegacy/git-intent/security/code-scanning/8)

In general, this type of problem is fixed by explicitly declaring a `permissions` block for the workflow or for each job, restricting the `GITHUB_TOKEN` to only the scopes actually needed. For a code‑quality workflow that only checks out code and runs local analysis, `contents: read` is typically sufficient.

For this specific workflow in `.github/workflows/code-quality.yml`, the simplest, non‑breaking fix is to add a root‑level `permissions` block (applies to all jobs) with `contents: read`. The job only needs to read the repository contents (via `actions/checkout@v4`) and does not require any write access or other scopes. No other permissions (like `pull-requests` or `issues`) are needed based on the current steps.

You should edit `.github/workflows/code-quality.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `name:` and `on:` keys (or alternatively between `on:` and `jobs:`; root level is what matters). No imports or additional methods are needed, since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
